### PR TITLE
Implement ECS-lite components across simulation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Week 0–1: Skeleton & Determinism
 - [x] Fixed-step sim @ 60 Hz with seeded RNG
-- [ ] ECS-lite components: Transform, Kinematics, Health, Shield, Weapon, Faction
+- [x] ECS-lite components: Transform, Kinematics, Health, Shield, Weapon, Faction
 - [ ] Weapon system: hitscan pistol; projectile frag with arc
 - [ ] LOS & simple cover tags
 - [ ] Mode controllers: Real-time, Turn, We-Go (3–5 s slices)

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -5,13 +5,51 @@ export type Vec2 = {
 
 export type Faction = 'Blue' | 'Red';
 
+export interface TransformComponent {
+  position: Vec2;
+  facing: Vec2;
+}
+
+export interface KinematicsComponent {
+  maxSpeed: number;
+  velocity: Vec2;
+}
+
+export interface HealthComponent {
+  current: number;
+  max: number;
+}
+
+export interface ShieldComponent {
+  current: number;
+  max: number;
+  rechargeRate: number;
+}
+
+export type WeaponType = 'hitscan' | 'projectile';
+
+export interface WeaponComponent {
+  name: string;
+  type: WeaponType;
+  range: number;
+  damage: number;
+  fireRate: number;
+  cooldownRemaining: number;
+}
+
+export interface FactionComponent {
+  team: Faction;
+}
+
 export interface Unit {
   id: number;
   name: string;
-  faction: Faction;
-  pos: Vec2;
-  aim: Vec2;
-  speed: number;
+  transform: TransformComponent;
+  kinematics: KinematicsComponent;
+  health: HealthComponent;
+  shield?: ShieldComponent;
+  weapon: WeaponComponent;
+  faction: FactionComponent;
   waypoints: Vec2[];
 }
 

--- a/src/game/Scenarios.ts
+++ b/src/game/Scenarios.ts
@@ -1,5 +1,5 @@
 import type { Sim } from '@engine/Sim';
-import type { Unit, Vec2 } from '@engine/types';
+import type { Faction, Unit, Vec2 } from '@engine/types';
 
 type ScenarioName = 'duel' | 'breach';
 
@@ -31,14 +31,48 @@ export function makeScenario(sim: Sim, name: ScenarioName): void {
   sim.loadScenario({ units: factory(), seed: scenarioSeeds[name] ?? 1 });
 }
 
-function makeUnit(id: number, faction: Unit['faction'], name: string, pos: Vec2): Unit {
+function makeUnit(id: number, faction: Faction, name: string, pos: Vec2): Unit {
+  const isBlue = faction === 'Blue';
   return {
     id,
-    faction,
     name,
-    pos: { ...pos },
-    aim: { x: 1, y: 0 },
-    speed: faction === 'Blue' ? 1.8 : 1.4,
+    faction: { team: faction },
+    transform: {
+      position: { ...pos },
+      facing: { x: 1, y: 0 },
+    },
+    kinematics: {
+      maxSpeed: isBlue ? 1.8 : 1.4,
+      velocity: { x: 0, y: 0 },
+    },
+    health: {
+      current: isBlue ? 100 : 90,
+      max: isBlue ? 100 : 90,
+    },
+    shield: isBlue
+      ? {
+          current: 25,
+          max: 25,
+          rechargeRate: 5,
+        }
+      : undefined,
+    weapon: isBlue
+      ? {
+          name: 'M7 SMG',
+          type: 'hitscan',
+          range: 12,
+          damage: 8,
+          fireRate: 10,
+          cooldownRemaining: 0,
+        }
+      : {
+          name: 'Plasma Rifle',
+          type: 'projectile',
+          range: 10,
+          damage: 10,
+          fireRate: 8,
+          cooldownRemaining: 0,
+        },
     waypoints: [],
   };
 }

--- a/src/render/PixiApp.ts
+++ b/src/render/PixiApp.ts
@@ -59,14 +59,18 @@ export class PixiApp {
 
     this.worldLayer.removeChildren();
     for (const u of world.units) {
+      const pos = u.transform.position;
       const g = new Graphics();
-      g.circle(u.pos.x * 64, u.pos.y * 64, 10);
-      g.fill({ color: u.faction === 'Blue' ? 0x66aaff : 0xff6688 });
+      g.circle(pos.x * 64, pos.y * 64, 10);
+      g.fill({ color: u.faction.team === 'Blue' ? 0x66aaff : 0xff6688 });
       this.worldLayer.addChild(g);
 
       const aim = new Graphics();
-      aim.moveTo(u.pos.x * 64, u.pos.y * 64);
-      aim.lineTo(u.pos.x * 64 + u.aim.x * 24, u.pos.y * 64 + u.aim.y * 24);
+      aim.moveTo(pos.x * 64, pos.y * 64);
+      aim.lineTo(
+        pos.x * 64 + u.transform.facing.x * 24,
+        pos.y * 64 + u.transform.facing.y * 24,
+      );
       aim.stroke({ width: 2, color: 0xffffff, alpha: 0.4 });
       this.worldLayer.addChild(aim);
     }

--- a/src/render/PlanningOverlay.ts
+++ b/src/render/PlanningOverlay.ts
@@ -107,7 +107,7 @@ export class PlanningOverlay {
       return undefined;
     }
     const u = this.world.units.find((unit) => unit.id === this.plan.unitId);
-    return u?.pos;
+    return u?.transform.position;
   }
 
   private screenToWorld(x: number, y: number) {

--- a/src/ui/PolicyUI.ts
+++ b/src/ui/PolicyUI.ts
@@ -40,15 +40,23 @@ export class PolicyUI {
       <h3>Units</h3>
       <ul>
         ${world.units
-          .map(
-            (unit) => `
+          .map((unit) => {
+            const pos = unit.transform.position;
+            const hpPct = ((unit.health.current / unit.health.max) * 100).toFixed(0);
+            const shield = unit.shield
+              ? `${unit.shield.current.toFixed(0)}/${unit.shield.max.toFixed(0)}`
+              : '—';
+            return `
               <li>
                 <strong>${unit.name}</strong>
-                <div>Faction: ${unit.faction}</div>
-                <div>Position: ${unit.pos.x.toFixed(2)}, ${unit.pos.y.toFixed(2)}</div>
+                <div>Faction: ${unit.faction.team}</div>
+                <div>Position: ${pos.x.toFixed(2)}, ${pos.y.toFixed(2)}</div>
+                <div>Health: ${unit.health.current.toFixed(0)}/${unit.health.max.toFixed(0)} (${hpPct}%)</div>
+                <div>Shield: ${shield}</div>
+                <div>Weapon: ${unit.weapon.name} (${unit.weapon.type})</div>
               </li>
-            `,
-          )
+            `;
+          })
           .join('')}
       </ul>
     `;


### PR DESCRIPTION
## Summary
- introduce ECS-lite component definitions for units covering transform, kinematics, health, shields, weapons, and faction data
- refactor the simulation, scenarios, renderer, and planning/UI layers to consume the new componentized unit shape
- update the roadmap to reflect completion of the ECS-lite component milestone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7b83dc5a4832b866e54024aa2bd58